### PR TITLE
prometheus: add an attributes namespace option for prometheus metrics

### DIFF
--- a/lib/metrics/prometheus.go
+++ b/lib/metrics/prometheus.go
@@ -37,6 +37,7 @@ func WithNamespace(namespace string) PrometheusOption {
 	}
 }
 
+// WithAttributesNamespace sets the prometheus namespace for GaugeVec attributes
 func WithAttributesNamespace(namespace string) PrometheusOption {
 	return func(m *Prometheus) {
 		m.attributesNamespace = namespace

--- a/lib/metrics/prometheus_test.go
+++ b/lib/metrics/prometheus_test.go
@@ -78,6 +78,35 @@ func TestRecord(t *testing.T) {
 	assert.Equal(t, float64(6), v)
 }
 
+func TestRecordWithAttributesNamespace(t *testing.T) {
+	// Given
+	customRegistry := prometheus.NewRegistry()
+
+	metrics := NewPrometheus(
+		"my-test-service-name",
+		WithRegisterer(customRegistry),
+		WithAttributesNamespace("gocache"),
+	)
+
+	// When
+	metrics.record("redis", "hit_count", 6)
+
+	// Then
+	metric, err := metrics.collector.GetMetricWith(
+		prometheus.Labels{
+			"gocache_service": "my-test-service-name",
+			"gocache_store":   "redis",
+			"gocache_metric":  "hit_count",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v := testutil.ToFloat64(metric)
+
+	assert.Equal(t, float64(6), v)
+}
+
 func TestRecordFromCodec(t *testing.T) {
 	// Given
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
Resolves https://github.com/eko/gocache/issues/288

This PR adds an attribute namespace option for Prometheus metrics.

It's empty by default so it guarantees backward compatibility. 